### PR TITLE
Add deployment documentation and usage instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Pre-requisites
 
-* [Chef Infra] or [Cinc Client]
+* [Chef Infra] or [Cinc Client] v15
 * Git
 * Ubuntu 20.04
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
-# Overview
+# Chef deployment repository for ROS build farm
 
-Every Chef Infra installation needs a Chef Repository. This is the place where cookbooks, policyfiles, config files and other artifacts for managing systems with Chef Infra will live. We strongly recommend storing this repository in a version control system such as Git and treating it like source code.
+## Pre-requisites
 
-# Repository Directories
+* [Chef Infra] or [Cinc Client]
+* Git
+* Ubuntu 20.04
 
-This repository contains several directories, and each directory contains a README file that describes what it is for in greater detail, and how to use it for managing your systems with Chef.
+## Deployment
 
-- `cookbooks/` - Cookbooks you download or create.
-- `data_bags/` - Store data bags and items in .json in the repository.
-- `roles/` - Store roles in .rb or .json in the repository.
-- `environments/` - Store environments in .rb or .json in the repository.
+1. Create a solo.json file.
+```bash
+echo '{ "run_list": ["recipe[ros_buildarm::jenkins]"] }' > solo.json
+```
 
-# Configuration
-
-The config file, `.chef/config.rb` is a repository-specific configuration file for the knife command line tool. If you're using the Hosted Chef platform, you can download one for your organization from the management console. You can also generate a new config.rb by running `knife configure`. For more information about configuring Knife, see the Knife documentation at https://docs.chef.io/workstation/knife/
-
-# Next Steps
+2. Run chef-solo
+```bash
+chef-solo -c $(pwd)/.chef/solo.rb -E development -j $(pwd)/solo.json
+```
 
 Read the README file in each of the subdirectories for more information about what goes in those directories.
+
+[Chef Infra]: https://www.chef.io/products/chef-infra
+[Cinc Client]: https://cinc.sh/start/client/


### PR DESCRIPTION
- [ ] Prerequisites
- [ ] Host requirements and recommenations
- [ ] Populating required and recommended configuration options
- [ ] Installing chef on the target host
- [ ] Running chef on the target host